### PR TITLE
Refactor batch group inversion scratch buffer

### DIFF
--- a/lib/ecc.c
+++ b/lib/ecc.c
@@ -25,6 +25,7 @@ INLINE u64 umul128(const u64 a, const u64 b, u64 *hi) {
 // MARK: Field Element
 typedef u64 fe[4];    // 256bit as 4x64bit (a0 + a1*2^64 + a2*2^128 + a3*2^192)
 typedef u64 fe320[5]; // 320bit as 5x64bit (a0 + a1*2^64 + a2*2^128 + a3*2^192 + a4*2^256)
+static_assert(sizeof(fe) == 32, "fe expected to be 256-bit");
 
 GLOBAL fe FE_ZERO = {0, 0, 0, 0};
 
@@ -519,8 +520,11 @@ void _fe_modp_inv_addchn(fe r, const fe a) {
 
 INLINE void fe_modp_inv(fe r, const fe a) { return _fe_modp_inv_addchn(r, a); }
 
-void fe_modp_grpinv(fe r[], const u32 n) {
-  fe *zs = (fe *)malloc(n * sizeof(fe));
+void fe_modp_grpinv(fe r[], const u32 n, fe tmp[]) {
+  assert(tmp != NULL); // why: caller must provide workspace
+  assert(n > 0);      // why: empty range invalid
+
+  fe *zs = tmp;       // why: reuse caller buffer for products
 
   fe_clone(*zs, r[0]);
   for (u32 i = 1; i < n; ++i) fe_modp_mul(*(zs + i), *(zs + (i - 1)), r[i]);
@@ -536,7 +540,6 @@ void fe_modp_grpinv(fe r[], const u32 n) {
   }
 
   fe_clone(r[0], t1);
-  free(zs);
 }
 
 // MARK: EC Point
@@ -693,9 +696,10 @@ void _ec_jacobi_rdc1(pe *r, const pe *a) {
 }
 
 void _ec_jacobi_grprdc1(pe r[], u64 n) {
-  fe *zz = (fe *)malloc(n * sizeof(fe));
+  fe zz[n];      // z-coordinates
+  fe tmp[n];     // scratch for inversion
   for (u64 i = 0; i < n; ++i) fe_clone(zz[i], r[i].z);
-  fe_modp_grpinv(zz, n);
+  fe_modp_grpinv(zz, n, tmp);
 
   for (u64 i = 0; i < n; ++i) {
     fe_modp_mul(r[i].x, r[i].x, zz[i]);
@@ -703,7 +707,6 @@ void _ec_jacobi_grprdc1(pe r[], u64 n) {
     fe_set64(r[i].z, 0x1);
   }
 
-  free(zz);
 }
 
 // https://en.wikibooks.org/wiki/Cryptography/Prime_Curve/Jacobian_Coordinates
@@ -789,9 +792,10 @@ void _ec_jacobi_rdc2(pe *r, const pe *a) {
 }
 
 void _ec_jacobi_grprdc2(pe r[], u64 n) {
-  fe *zz = (fe *)malloc(n * sizeof(fe));
+  fe zz[n];  // z coordinates
+  fe tmp[n]; // scratch buffer
   for (u64 i = 0; i < n; ++i) fe_clone(zz[i], r[i].z);
-  fe_modp_grpinv(zz, n);
+  fe_modp_grpinv(zz, n, tmp);
 
   fe z = {0};
   for (u64 i = 0; i < n; ++i) {
@@ -802,7 +806,6 @@ void _ec_jacobi_grprdc2(pe r[], u64 n) {
     fe_set64(r[i].z, 0x1);
   }
 
-  free(zz);
 }
 
 // v1. add: ~6.6M it/s, dbl: ~5.6M it/s

--- a/main.c
+++ b/main.c
@@ -351,6 +351,7 @@ void batch_add(ctx_t *ctx, const fe pk, const size_t iterations) {
 
   pe bp[GROUP_INV_SIZE]; // calculated ec points
   fe dx[hsize];          // delta x for group inversion
+  fe tmp[hsize];         // scratch for inversion
   pe GStart;             // iteration points
   fe ck, rx, ry;         // current start point; tmp for x3, y3
   fe ss, dd;             // temp variables
@@ -367,7 +368,7 @@ void batch_add(ctx_t *ctx, const fe pk, const size_t iterations) {
   size_t counter = 0;
   while (counter < iterations) {
     for (size_t i = 0; i < hsize; ++i) fe_modp_sub(dx[i], ctx->gpoints[i].x, GStart.x);
-    fe_modp_grpinv(dx, hsize);
+    fe_modp_grpinv(dx, hsize, tmp);
 
     pe_clone(&bp[hsize + 0], &GStart); // set K value
 


### PR DESCRIPTION
## Summary
- pass a preallocated scratch buffer to `fe_modp_grpinv`
- allocate inversion work buffers on the stack for Jacobi batch reducers and `batch_add`
- ensure `fe` size is validated at compile time

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6841e20f23a88326b84698fe56186319