### PR TITLE
Fix fe_clone overlap warning

### DIFF
--- a/lib/ecc.c
+++ b/lib/ecc.c
@@ -43,7 +43,10 @@ INLINE void fe_print(const char *label, const fe a) {
 }
 
 INLINE bool fe_iszero(const fe r) { return r[0] == 0 && r[1] == 0 && r[2] == 0 && r[3] == 0; }
-INLINE void fe_clone(fe r, const fe a) { memcpy(r, a, sizeof(fe)); }
+// fe_clone copies a into r, but the pointers may alias
+INLINE void fe_clone(fe r, const fe a) {
+  if (r != a) memmove(r, a, sizeof(fe));
+}
 INLINE void fe_set64(fe r, const u64 a) {
   memset(r, 0, sizeof(fe));
   r[0] = a;


### PR DESCRIPTION
## Summary
- fix potential aliasing in `fe_clone` by checking pointers and using `memmove`

## Testing
- `make fmt`
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6841e2dad8208326967d8aa946d17a5d