### PR TITLE
Fix fe_clone definition

### DIFF
--- a/lib/ecc.c
+++ b/lib/ecc.c
@@ -49,13 +49,9 @@ INLINE void fe_print(const char *label, const fe a) {
 
 INLINE bool fe_iszero(const fe r) { return r[0] == 0 && r[1] == 0 && r[2] == 0 && r[3] == 0; }
 
-INLINE void fe_clone(fe r, const fe a) {
-  if (r != a) memcpy(r, a, sizeof(fe));
-
-// fe_clone copies a into r, but the pointers may alias
+// fe_clone copies a into r and handles aliasing via memmove
 INLINE void fe_clone(fe r, const fe a) {
   if (r != a) memmove(r, a, sizeof(fe));
-
 }
 INLINE void fe_set64(fe r, const u64 a) {
   memset(r, 0, sizeof(fe));


### PR DESCRIPTION
## Summary
- remove duplicate fe_clone and always use memmove so aliasing is safe

## Testing
- `make build`
- `sh tests/run_fe_clone.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841e4b18b848326a9e45f88a5d8538d