### PR TITLE
Fix struct redefinition issue

### DIFF
--- a/lib/ecc.c
+++ b/lib/ecc.c
@@ -554,9 +554,12 @@ void fe_modp_grpinv(fe r[], const u32 n, fe tmp[]) {
 // https://eprint.iacr.org/2015/1060.pdf
 // https://hyperelliptic.org/EFD/g1p/auto-shortw.html
 
+#ifndef PE_DEFINED
 typedef struct pe {
   fe x, y, z;
 } pe;
+#define PE_DEFINED
+#endif
 
 GLOBAL pe G1 = {
     .x = {0x59f2815b16f81798, 0x029bfcdb2dce28d9, 0x55a06295ce870b07, 0x79be667ef9dcbbac},

--- a/lib/ecc_cuda.cu
+++ b/lib/ecc_cuda.cu
@@ -8,10 +8,12 @@ typedef unsigned long long u64;
 typedef unsigned int u32;
 typedef unsigned char u8;
 typedef u64 fe[4];
-
+#ifndef PE_DEFINED
 typedef struct pe {
   fe x, y, z;
 } pe;
+#define PE_DEFINED
+#endif
 
 static_assert(IS_LITTLE_ENDIAN, "CUDA code requires little-endian");
 static_assert(sizeof(fe)==32, "fe size");

--- a/lib/ecc_cuda.h
+++ b/lib/ecc_cuda.h
@@ -6,10 +6,12 @@ typedef unsigned int u32;
 typedef unsigned char u8;
 
 typedef u64 fe[4];
-
+#ifndef PE_DEFINED
 typedef struct pe {
   fe x, y, z;
 } pe;
+#define PE_DEFINED
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/run_cuda_include.sh
+++ b/tests/run_cuda_include.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cc -DWITH_CUDA tests/test_cuda_include.c -o tests/test_cuda_include && echo "cuda include test passed"

--- a/tests/test_cuda_include.c
+++ b/tests/test_cuda_include.c
@@ -1,0 +1,3 @@
+#include "../lib/ecc.c"
+#include "../lib/ecc_cuda.h"
+int main(){return 0;}


### PR DESCRIPTION
## Summary
- guard `pe` struct definition in ecc files to avoid multiple definitions
- add compile test covering CUDA header include order

## Testing
- `make build`
- `tests/run_fe_clone.sh`
- `tests/run_endian.sh`
- `tests/run_cuda_include.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841edf7de6c83269ec36efb127f74ea